### PR TITLE
Add gulp 'watch' refresh on changes to .twig

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -255,7 +255,7 @@ gulp.task('clean', require('del').bind(null, [path.dist]));
 // See: http://www.browsersync.io
 gulp.task('watch', function() {
   browserSync.init({
-    files: ['{lib,templates}/**/*.php', '*.php'],
+    files: ['{lib,templates}/**/*.php', '*.php', '{lib,templates}/**/*.twig', '*.twig'],
     proxy: config.devUrl,
     snippetOptions: {
       whitelist: ['/wp-admin/admin-ajax.php'],


### PR DESCRIPTION
Add .twig files to the browserSync.init files list, so saving .twig files will refresh the browser. This was my expected behavior, at least.