### PR TITLE
Fix location for content.twig

### DIFF
--- a/templates/pages/search.twig
+++ b/templates/pages/search.twig
@@ -10,7 +10,7 @@
     {% endif %}
 
     {% for post in posts %}
-        {% include "templates/content.twig" with {post: post}  %}
+        {% include "templates/blocks/content.twig" with {post: post}  %}
     {% endfor %}
 
     {{ function('the_posts_navigation') }}


### PR DESCRIPTION
Using search box generated a template error, because content.twig is in the blocks/ subfolder.